### PR TITLE
Allow for multiple teams in route guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ github_authenticated(team: 'markting') do
   get '/dashboard' => 'dashboard#show'
 end
 
+# Matches if a member of any of the teams given. Does not initiate login if not logged in.
+github_authenticated(team: ['markting', 'graphic-design']) do
+  get '/dashboard' => 'dashboard#show'
+end
+
 # Using dynamic membership values:
 github_authenticate(org: lambda { |req| req.params[:id] }) do
   get '/orgs/:id' => 'orgs#show'

--- a/lib/warden/github/rails/routes.rb
+++ b/lib/warden/github/rails/routes.rb
@@ -58,8 +58,7 @@ module Warden
 
         def github_enforce_options(user, options)
           if (teams = options[:team])
-            teams = [teams] unless teams.respond_to?(:each)
-            teams.any? { |team| user.team_member?(Rails.team_id(team)) }
+            Array(teams).any? { |team| user.team_member?(Rails.team_id(team)) }
           elsif (org = options[:org] || options[:organization])
             user.organization_member?(org)
           else

--- a/lib/warden/github/rails/routes.rb
+++ b/lib/warden/github/rails/routes.rb
@@ -57,8 +57,9 @@ module Warden
         end
 
         def github_enforce_options(user, options)
-          if (team = options[:team])
-            user.team_member?(Rails.team_id(team))
+          if (teams = options[:team])
+            teams = [teams] unless teams.respond_to?(:each)
+            teams.any? { |team| user.team_member?(Rails.team_id(team)) }
           elsif (org = options[:org] || options[:organization])
             user.organization_member?(org)
           else

--- a/spec/integration/membership_spec.rb
+++ b/spec/integration/membership_spec.rb
@@ -140,6 +140,33 @@ describe 'request to a resource that only exists when logged in' do
       end
     end
 
+    context 'which is specified by multiple numeric team ids' do
+      subject { get '/multiple_teams/conditional' }
+
+      context 'when a first team member' do
+        before do
+          user = github_login
+          user.stub_membership(team: 123)
+        end
+
+        it { is_expected.to be_ok }
+      end
+
+      context 'when another team member' do
+        before do
+          user = github_login
+          user.stub_membership(team: 345)
+        end
+
+        it { is_expected.to be_ok }
+      end
+
+      context 'when not team member' do
+        before { github_login }
+        it { is_expected.to be_not_found}
+      end
+    end
+
     context 'which is specified by a team alias' do
       subject { get '/team_alias/conditional' }
 
@@ -153,6 +180,33 @@ describe 'request to a resource that only exists when logged in' do
       end
 
       context 'when not team member' do
+        before { github_login }
+        it { is_expected.to be_not_found}
+      end
+    end
+
+    context 'which specifies multiple team aliases' do
+      subject { get '/multiple_team_aliases/conditional' }
+
+      context 'when a member of the first team' do
+        before do
+          user = github_login
+          user.stub_membership(team: 456)
+        end
+
+        it { is_expected.to be_ok }
+      end
+
+      context 'when a member of another team' do
+        before do
+          user = github_login
+          user.stub_membership(team: 789)
+        end
+
+        it { is_expected.to be_ok }
+      end
+
+      context 'when not a team member' do
         before { github_login }
         it { is_expected.to be_not_found}
       end

--- a/spec/rails_app/config/initializers/warden_github_rails.rb
+++ b/spec/rails_app/config/initializers/warden_github_rails.rb
@@ -9,4 +9,5 @@ Warden::GitHub::Rails.setup do |config|
                            scope:         'repo'
 
   config.add_team :marketing, 456
+  config.add_team :interns,   789
 end

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -17,9 +17,11 @@ RailsApp::Application.routes.draw do
 
   github_authenticate(team: 123)  { get '/team/protected'   => responses[200] }
   github_authenticated(team: 123) { get '/team/conditional' => responses[200] }
+  github_authenticated(team: [123, 345]) { get '/multiple_teams/conditional' => responses[200] }
 
   github_authenticate(team: :marketing)  { get '/team_alias/protected'   => responses[200] }
   github_authenticated(team: :marketing) { get '/team_alias/conditional' => responses[200] }
+  github_authenticated(team: [:marketing, :interns]) { get '/multiple_team_aliases/conditional' => responses[200] }
 
   github_authenticate(org: :foobar_inc)  { get '/org/protected'   => responses[200] }
   github_authenticated(org: :foobar_inc) { get '/org/conditional' => responses[200] }


### PR DESCRIPTION
Allows for multiple teams in route guards, like:

```
  github_authenticate(:team => ['employees', 'contractors']) do
    get "/foo" => "foo#bar"
  end
```

This will allow members of both the employees and contractors team to access the foo route.

The old way of specifying a single team also still works.