### PR TITLE
Add warden config to not intercept 401 status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- Add warden config to not intercept 401 status
+
 ## v1.1.2
 
 - Prevent loss of memberships in mocked user when marshaling

--- a/lib/warden/github/rails/railtie.rb
+++ b/lib/warden/github/rails/railtie.rb
@@ -13,6 +13,7 @@ module Warden
             app.config.middleware.use Warden::Manager do |config|
               setup_failure_app(config)
               setup_scopes(config)
+              config.intercept_401 = false
             end
           end
         end
@@ -39,4 +40,3 @@ module Warden
     end
   end
 end
-


### PR DESCRIPTION
This will prevent warden intercepting `401` responses by default - same config is used by Devise here https://github.com/plataformatec/devise/blob/4b41dab11ba046804824ee358ac7d689484acacf/lib/devise.rb#L445

Right now responding with `401` from an unrelated endpoint (not configured with github_authenticate), will trigger warden `failure_app` response.