### PR TITLE
Add support for Rails 4.2 via warden-github 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - Add warden config to not intercept 401 status
+- Support Rails 4.2 default of JSON marshalling
 
 ## v1.1.2
 

--- a/lib/warden/github/rails/railtie.rb
+++ b/lib/warden/github/rails/railtie.rb
@@ -14,6 +14,8 @@ module Warden
               setup_failure_app(config)
               setup_scopes(config)
               config.intercept_401 = false
+              config.serialize_from_session { |key| Warden::GitHub::Verifier.load(key) }
+              config.serialize_into_session { |user| Warden::GitHub::Verifier.dump(user) }
             end
           end
         end

--- a/warden-github-rails.gemspec
+++ b/warden-github-rails.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'addressable', '~> 2.3'
   gem.add_development_dependency 'coveralls' if RUBY_ENGINE == 'ruby'
 
-  gem.add_dependency 'warden-github', '~> 1.0'
+  gem.add_dependency 'warden-github', '~> 1.1', '>= 1.1.1'
   gem.add_dependency 'railties', '>= 3.1'
 end


### PR DESCRIPTION
So it turns out that Rails 4.2 changed the default serialization from Marshal to JSON. This meant that Warden::Github stopped deserializing users correctly, and for whatever reason, the `github_user` object became a simple Hash instead of an Octokit::User.

The problem (reported in https://github.com/atmos/warden-github/issues/38), goes away once you start using [warden-github's explicit serialization and deserialization code](https://github.com/atmos/warden-github/commit/8b4d76c4a8399490b90e2164e489537a6be70add) rather than warden's default to Rails' default.

This change simply uses that explicit serialization code, as suggested by warden-github since version 1.1.1.